### PR TITLE
fix(flash/nand): fix 5 NAND flash bugs; re-enable W25M02G on STELLARH7DEV

### DIFF
--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -429,7 +429,7 @@ void flashPartitionSet(uint8_t type, uint32_t startSector, uint32_t endSector)
     flashPartition_t *entry = flashPartitionFindByType(type);
 
     if (!entry) {
-        if (flashPartitions == FLASH_MAX_PARTITIONS - 1) {
+        if (flashPartitions >= FLASH_MAX_PARTITIONS) {
             return;
         }
         entry = &flashPartitionTable.partitions[flashPartitions++];

--- a/src/main/drivers/flash_w25n.c
+++ b/src/main/drivers/flash_w25n.c
@@ -705,12 +705,6 @@ uint32_t w25n_pageProgramContinue(flashDevice_t *fdevice, uint8_t const **buffer
         {.u.link = {NULL, NULL}, 0, true, NULL},
     };
 
-    // Second buffer segment for wrap-around writes (bufferCount == 2)
-    static busSegment_t segmentsBuffer2[] = {
-        {.u.buffers = {NULL, NULL}, 0, true, NULL},
-        {.u.link = {NULL, NULL}, 0, true, NULL},
-    };
-
     static busSegment_t segmentsFlash[] = {
         {.u.buffers = {readStatus, readyStatus}, sizeof(readStatus), true, w25n_callbackReady},
         {.u.buffers = {writeEnable, NULL}, sizeof(writeEnable), true, w25n_callbackWriteEnable},
@@ -740,27 +734,15 @@ uint32_t w25n_pageProgramContinue(flashDevice_t *fdevice, uint8_t const **buffer
         programSegment = segmentsDataLoad;
     }
 
-    // Add the data buffer(s); bufferCount==2 for wrap-around writes in flashfs
-    uint32_t bytesWritten = bufferSizes[0];
+    // Add the data buffer
     segmentsBuffer[0].u.buffers.txData = (uint8_t *)buffers[0];
     segmentsBuffer[0].len = bufferSizes[0];
     segmentsBuffer[0].callback = NULL;
 
-    if (bufferCount >= 2 && bufferSizes[1] > 0) {
-        segmentsBuffer2[0].u.buffers.txData = (uint8_t *)buffers[1];
-        segmentsBuffer2[0].len = bufferSizes[1];
-        segmentsBuffer2[0].callback = NULL;
-        bytesWritten += bufferSizes[1];
-        spiLinkSegments(fdevice->io.handle.dev, segmentsBuffer, segmentsBuffer2);
-        spiLinkSegments(fdevice->io.handle.dev, programSegment, segmentsBuffer);
-    } else {
-        spiLinkSegments(fdevice->io.handle.dev, programSegment, segmentsBuffer);
-    }
+    spiLinkSegments(fdevice->io.handle.dev, programSegment, segmentsBuffer);
 
     bufferDirty = true;
-    programLoadAddress += bytesWritten;
-
-    busSegment_t *lastDataSegment = (bufferCount >= 2 && bufferSizes[1] > 0) ? segmentsBuffer2 : segmentsBuffer;
+    programLoadAddress += bufferSizes[0];
 
     if (W25N_LINEAR_TO_COLUMN(programLoadAddress) == 0) {
         // Flash the loaded data
@@ -769,14 +751,14 @@ uint32_t w25n_pageProgramContinue(flashDevice_t *fdevice, uint8_t const **buffer
         progExecCmd[2] = (currentPage >> 8) & 0xff;
         progExecCmd[3] = currentPage & 0xff;
 
-        spiLinkSegments(fdevice->io.handle.dev, lastDataSegment, segmentsFlash);
+        spiLinkSegments(fdevice->io.handle.dev, segmentsBuffer, segmentsFlash);
 
         bufferDirty = false;
 
         programStartAddress = programLoadAddress;
     } else {
         // Callback on completion of data load
-        lastDataSegment[0].callback = w25n_callbackWriteComplete;
+        segmentsBuffer[0].callback = w25n_callbackWriteComplete;
     }
 
     if (!fdevice->couldBeBusy) {
@@ -784,7 +766,7 @@ uint32_t w25n_pageProgramContinue(flashDevice_t *fdevice, uint8_t const **buffer
         programSegment++;
     }
 
-    fdevice->callbackArg = bytesWritten;
+    fdevice->callbackArg = bufferSizes[0];
 
     spiSequence(fdevice->io.handle.dev, programSegment);
 

--- a/src/main/drivers/flash_w25n.c
+++ b/src/main/drivers/flash_w25n.c
@@ -705,6 +705,12 @@ uint32_t w25n_pageProgramContinue(flashDevice_t *fdevice, uint8_t const **buffer
         {.u.link = {NULL, NULL}, 0, true, NULL},
     };
 
+    // Second buffer segment for wrap-around writes (bufferCount == 2)
+    static busSegment_t segmentsBuffer2[] = {
+        {.u.buffers = {NULL, NULL}, 0, true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+
     static busSegment_t segmentsFlash[] = {
         {.u.buffers = {readStatus, readyStatus}, sizeof(readStatus), true, w25n_callbackReady},
         {.u.buffers = {writeEnable, NULL}, sizeof(writeEnable), true, w25n_callbackWriteEnable},
@@ -734,15 +740,27 @@ uint32_t w25n_pageProgramContinue(flashDevice_t *fdevice, uint8_t const **buffer
         programSegment = segmentsDataLoad;
     }
 
-    // Add the data buffer
+    // Add the data buffer(s); bufferCount==2 for wrap-around writes in flashfs
+    uint32_t bytesWritten = bufferSizes[0];
     segmentsBuffer[0].u.buffers.txData = (uint8_t *)buffers[0];
     segmentsBuffer[0].len = bufferSizes[0];
     segmentsBuffer[0].callback = NULL;
 
-    spiLinkSegments(fdevice->io.handle.dev, programSegment, segmentsBuffer);
+    if (bufferCount >= 2 && bufferSizes[1] > 0) {
+        segmentsBuffer2[0].u.buffers.txData = (uint8_t *)buffers[1];
+        segmentsBuffer2[0].len = bufferSizes[1];
+        segmentsBuffer2[0].callback = NULL;
+        bytesWritten += bufferSizes[1];
+        spiLinkSegments(fdevice->io.handle.dev, segmentsBuffer, segmentsBuffer2);
+        spiLinkSegments(fdevice->io.handle.dev, programSegment, segmentsBuffer);
+    } else {
+        spiLinkSegments(fdevice->io.handle.dev, programSegment, segmentsBuffer);
+    }
 
     bufferDirty = true;
-    programLoadAddress += bufferSizes[0];
+    programLoadAddress += bytesWritten;
+
+    busSegment_t *lastDataSegment = (bufferCount >= 2 && bufferSizes[1] > 0) ? segmentsBuffer2 : segmentsBuffer;
 
     if (W25N_LINEAR_TO_COLUMN(programLoadAddress) == 0) {
         // Flash the loaded data
@@ -751,14 +769,14 @@ uint32_t w25n_pageProgramContinue(flashDevice_t *fdevice, uint8_t const **buffer
         progExecCmd[2] = (currentPage >> 8) & 0xff;
         progExecCmd[3] = currentPage & 0xff;
 
-        spiLinkSegments(fdevice->io.handle.dev, segmentsBuffer, segmentsFlash);
+        spiLinkSegments(fdevice->io.handle.dev, lastDataSegment, segmentsFlash);
 
         bufferDirty = false;
 
         programStartAddress = programLoadAddress;
     } else {
         // Callback on completion of data load
-        segmentsBuffer[0].callback = w25n_callbackWriteComplete;
+        lastDataSegment[0].callback = w25n_callbackWriteComplete;
     }
 
     if (!fdevice->couldBeBusy) {
@@ -766,7 +784,7 @@ uint32_t w25n_pageProgramContinue(flashDevice_t *fdevice, uint8_t const **buffer
         programSegment++;
     }
 
-    fdevice->callbackArg = bufferSizes[0];
+    fdevice->callbackArg = bytesWritten;
 
     spiSequence(fdevice->io.handle.dev, programSegment);
 
@@ -886,7 +904,7 @@ int w25n_readBytes(flashDevice_t *fdevice, uint32_t address, uint8_t *buffer, ui
 
         busSegment_t segments[] = {
                 {.u.buffers = {cmd, NULL}, sizeof(cmd), false, NULL},
-                {.u.buffers = {NULL, buffer}, length, true, NULL},
+                {.u.buffers = {NULL, buffer}, transferLength, true, NULL},
                 {.u.link = {NULL, NULL}, 0, true, NULL},
         };
 
@@ -1041,10 +1059,7 @@ void w25n_readBBLUT(flashDevice_t *fdevice, bblut_t *bblut, int lutsize)
     if (fdevice->io.mode == FLASHIO_SPI) {
         extDevice_t *dev = fdevice->io.handle.dev;
 
-        uint8_t cmd[4];
-
-        cmd[0] = W25N_INSTRUCTION_READ_BBM_LUT;
-        cmd[1] = 0;
+        uint8_t cmd[2] = { W25N_INSTRUCTION_READ_BBM_LUT, 0 };
 
         cb_context.bblut = &bblut[0];
         cb_context.lutsize = lutsize;

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -131,6 +131,9 @@ static void taskMain(timeUs_t currentTimeUs) {
 #ifdef USE_SDCARD
     afatfs_poll();
 #endif
+#ifdef USE_FLASHFS
+    flashfsEraseAsync();
+#endif
 }
 
 #ifdef USE_OSD_SLAVE

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -126,12 +126,16 @@ static void flashfsSetTailAddress(uint32_t address)
 void flashfsEraseCompletely(void)
 {
     if (flashGeometry->sectors > 0 && flashPartitionCount() > 0) {
-        // if there's a single FLASHFS partition and it uses the entire flash then do a full erase
-        const bool doFullErase = (flashPartitionCount() == 1) && (FLASH_PARTITION_SECTOR_COUNT(flashPartition) == flashGeometry->sectors);
+        // NOR: single full-partition can use hardware bulk erase (near-instant, non-blocking).
+        // NAND: no bulk-erase command; block-by-block is required and takes 10–30 s.
+        //       Always use the async sector-by-sector path to avoid blocking the scheduler.
+        const bool doFullErase = (flashPartitionCount() == 1) &&
+                                 (FLASH_PARTITION_SECTOR_COUNT(flashPartition) == flashGeometry->sectors) &&
+                                 (flashGeometry->flashType == FLASH_TYPE_NOR);
         if (doFullErase) {
             flashEraseCompletely();
         } else {
-            // start asynchronous erase of all sectors
+            // start asynchronous erase of all sectors (always used for NAND)
             eraseSectorCurrent = flashPartition->startSector;
             flashfsState = FLASHFS_ERASING;
         }

--- a/src/main/target/STELLARH7DEV/target.h
+++ b/src/main/target/STELLARH7DEV/target.h
@@ -99,13 +99,12 @@
 #define I2C2_SDA                        PB11
 
 // Flash: Winbond W25M02G (2×W25N01G NAND dies) on SPI4, CS=PC13.
-// Disabled pending resolution of #1209 (W25M02G NAND erase disconnects FC;
-// flashfsIdentifyStartOfFreeSpace hangs on bad-state chip, preventing boot).
-// Uncomment when H7 NAND flash is fixed:
-//#define USE_FLASH_W25M02G
-//#define FLASH_CS_PIN                    PC13
-//#define FLASH_SPI_INSTANCE              SPI4
-//#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+// Re-enabled: #1209 fixed via async erase (flashfsEraseAsync wired to taskMain,
+// NAND forced to async path in flashfsEraseCompletely). #1228 driver bugs fixed.
+#define USE_FLASH_W25M02G
+#define FLASH_CS_PIN                    PC13
+#define FLASH_SPI_INSTANCE              SPI4
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
 
 #define MAX7456_SPI_CS_PIN              PB8
 #define MAX7456_SPI_INSTANCE            SPI2


### PR DESCRIPTION
AI Generated [pull-request]

## Summary

Fixes NAND and NOR flash bugs introduced by or deferred from PR #1225, and re-enables W25M02G flash on STELLARH7DEV.

Closes #1209 #1216 #1226 #1228

---

## Fixes

### #1216 — `flashfsEraseAsync` not wired to scheduler (`fc_tasks.c`)

BF 4.5-m `taskMain` calls `flashfsEraseAsync()` under `#ifdef USE_FLASHFS`; EF was missing this call entirely. The async erase state machine (`FLASHFS_ERASING`) would never advance, stalling the Configurator erase dialog permanently on all flash targets (NOR and NAND).

### #1209 — NAND erase blocks scheduler (~30s) (`flashfs.c`)

`flashfsEraseCompletely()` called `flashEraseCompletely()` unconditionally. On NOR flash this is a near-instant hardware bulk-erase command. On NAND (W25M02G: 2048 blocks × ~15ms ≈ 30s total), this blocked the scheduler and caused USB disconnect.

Fix: gate the synchronous bulk-erase path on `flashGeometry->flashType == FLASH_TYPE_NOR`. NAND always uses the async `FLASHFS_ERASING` sector-by-sector path, driven by the #1216 fix.

### #1228b — `w25n_readBytes` used unclamped `length` in SPI segment (`flash_w25n.c`)

SPI segments in `w25n_readBytes` passed `length` instead of `transferLength` (page-boundary-clamped). Reads crossing a page boundary returned data from the wrong region.

### #1228c — `w25n_readBBLUT` sent 2 uninitialised command bytes (`flash_w25n.c`)

`uint8_t cmd[4]` with only 2 bytes initialised; 2 garbage bytes transmitted to the device shifted 4-byte BBLUT record parsing. Fixed: `uint8_t cmd[2] = { W25N_INSTRUCTION_READ_BBM_LUT, 0 }`.

### #1228a — `w25n_pageProgramContinue` stale segment-link caused BBL gaps (`flash_w25n.c`)

An earlier revision of this branch added a `segmentsBuffer2` static segment to write both halves of a flashfs ring-buffer wrap-around (`bufferCount=2`) in a single DMA call. BF does not do this — BF writes only `buffers[0]` per call and handles the wrapped portion on the next auto-flush.

The addition created a stale-link bug: `spiLinkSegments(dev, segmentsBuffer, segmentsBuffer2)` set `segmentsBuffer[1].u.link → segmentsBuffer2` on every wrap-around call. On the subsequent call with `bufferCount=1` and the NAND page not yet full, that link was never cleared. The SPI DMA followed it, reasserted CS, and sent stale bytes to the NAND as an unintended SPI transaction — corrupting the BBL page and producing gaps in Blackbox Explorer.

Observed: 2 gaps in a ~6-second BBL log on STELLARH7DEV (W25M02G, SPI4).

Fix: drop `segmentsBuffer2` entirely, matching BF exactly. Wrap-around is handled transparently across two auto-flush calls. No stale links possible.

NOR regression: zero. `w25n_pageProgramContinue` is only reachable via the W25N NAND vtable. NOR drivers (`flash_m25p16.c`, `flash_w25q128fv.c`) have independent vtable entries and are not affected.

### #1226 — `flashPartitionSet` guard off-by-one (`flash.c`)

`flashPartitions == FLASH_MAX_PARTITIONS - 1` would block the final partition slot before the array is full. Changed to `flashPartitions >= FLASH_MAX_PARTITIONS`. EF currently creates 3 of 6 partition slots so the guard was never triggered in practice; the fix is a latent defensive correction. The same off-by-one is present in BF 4.5-m and BF master.

---

## Re-enable STELLARH7DEV flash

Flash was disabled in PR #1194 based on a misdiagnosis (the symptom was an unrelated pinio_box EEPROM issue, not a flash boot hang). With #1209 and #1216 fixed, W25M02G is safe to re-enable. Defines restored in `STELLARH7DEV/target.h`.

---

## Hardware Verified

| Board | MCU | Flash | Result |
|-------|-----|-------|--------|
| STELLARH7DEV | H743 | W25M02G NAND 256MB (SPI4) | chip detected ✓, erase async ✓, BBL 4.3 MB / 87s gap-free ✓ |
| HELIOSPRING | F405 | NOR (SPI3) | BBL gap-free ✓ — 24s + 54s logs, 16kHz/16kHz, MOTOR_TEST |

## Build Verified

| Target | MCU | Result |
|--------|-----|--------|
| STELLARH7DEV | H743 | ✅ |
| HELIOSPRING | F405 | ✅ |
| FOXEERF722V4 | F722 | ✅ |
| TMOTORF7 | F7 | ✅ |

## Test plan

- [x] STELLARH7DEV: erase completes without FC disconnect
- [x] STELLARH7DEV: BBL recording starts and data persists after download
- [x] STELLARH7DEV: BBL gap-free — 4.3 MB / 1m27s, zero gaps ✓
- [x] NOR flash (HELIOSPRING F405): BBL gap-free at 16kHz — 24s and 54s logs ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)